### PR TITLE
added waylandcompositor plugin deployer

### DIFF
--- a/src/deployers/CMakeLists.txt
+++ b/src/deployers/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CLASSES
     PrintSupportPluginsDeployer
     TextToSpeechPluginsDeployer
     TlsBackendsDeployer
+    WaylandcompositorPluginsDeployer
 )
 
 # TODO: CMake <= 3.7 (at least!) doesn't allow for using OBJECT libraries with target_link_libraries

--- a/src/deployers/PluginsDeployerFactory.cpp
+++ b/src/deployers/PluginsDeployerFactory.cpp
@@ -17,6 +17,7 @@
 #include "WebEnginePluginsDeployer.h"
 #include "XcbglIntegrationPluginsDeployer.h"
 #include "TlsBackendsDeployer.h"
+#include "WaylandcompositorPluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
 using namespace linuxdeploy::core::appdir;
@@ -101,6 +102,10 @@ std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeploye
 
     if (moduleName == "texttospeech") {
         return {getInstance<TextToSpeechPluginsDeployer>(moduleName)};
+    }
+
+    if (moduleName == "waylandcompositor") {
+        return {getInstance<WaylandcompositorPluginsDeployer>(moduleName)};
     }
 
     // fallback

--- a/src/deployers/WaylandcompositorPluginsDeployer.cpp
+++ b/src/deployers/WaylandcompositorPluginsDeployer.cpp
@@ -1,0 +1,38 @@
+// system headers
+#include <filesystem>
+
+// library headers
+#include <linuxdeploy/core/log.h>
+
+// local headers
+#include "WaylandcompositorPluginsDeployer.h"
+
+using namespace linuxdeploy::plugin::qt;
+using namespace linuxdeploy::core::log;
+
+namespace fs = std::filesystem;
+
+bool WaylandcompositorPluginsDeployer::deploy() {
+    // calling the default code is optional, but it won't hurt for now
+    if (!BasicPluginsDeployer::deploy())
+        return false;
+
+    ldLog() << "Deploying waylandcompositor plugin" << std::endl;
+
+    for (fs::directory_iterator i(qtPluginsPath / "wayland-decoration-client"); i != fs::directory_iterator(); ++i) {
+        if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins/wayland-decoration-client/"))
+            return false;
+    }
+
+    for (fs::directory_iterator i(qtPluginsPath / "wayland-graphics-integration-client"); i != fs::directory_iterator(); ++i) {
+        if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins/wayland-graphics-integration-client/"))
+            return false;
+    }
+
+    for (fs::directory_iterator i(qtPluginsPath / "wayland-shell-integration"); i != fs::directory_iterator(); ++i) {
+        if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins/wayland-shell-integration/"))
+            return false;
+    }
+
+    return true;
+}

--- a/src/deployers/WaylandcompositorPluginsDeployer.h
+++ b/src/deployers/WaylandcompositorPluginsDeployer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "BasicPluginsDeployer.h"
+
+namespace linuxdeploy {
+    namespace plugin {
+        namespace qt {
+            class WaylandcompositorPluginsDeployer : public BasicPluginsDeployer {
+            public:
+                // we can just use the base class's constructor
+                using BasicPluginsDeployer::BasicPluginsDeployer;
+
+                bool deploy() override;
+            };
+        }
+    }
+}


### PR DESCRIPTION
I added a class to deploy the following 3 plugin directories:

* wayland-decoration-client
* wayland-graphics-integration-client
* wayland-shell-integration

when the plugin *waylandcompositor* is selected.

I confirmed my specific app working with wayland like this. Here are the environment variables I set:

```bash
export EXTRA_QT_PLUGINS="waylandcompositor"
export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
```