### PR TITLE
Fix linuxdeploy log directory rename

### DIFF
--- a/src/deployers/BasicPluginsDeployer.cpp
+++ b/src/deployers/BasicPluginsDeployer.cpp
@@ -3,12 +3,12 @@
 #include <utility>
 
 // library headers
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 
 // local headers
 #include "BasicPluginsDeployer.h"
 
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 using namespace linuxdeploy::core::appdir;
 using namespace linuxdeploy::plugin::qt;
 

--- a/src/deployers/Multimedia6PluginsDeployer.cpp
+++ b/src/deployers/Multimedia6PluginsDeployer.cpp
@@ -2,13 +2,13 @@
 #include <filesystem>
 
 // library headers
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 
 // local headers
 #include "Multimedia6PluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 
 namespace fs = std::filesystem;
 

--- a/src/deployers/PlatformPluginsDeployer.cpp
+++ b/src/deployers/PlatformPluginsDeployer.cpp
@@ -2,14 +2,14 @@
 #include <filesystem>
 
 // library headers
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 #include <linuxdeploy/util/util.h>
 
 // local headers
 #include "PlatformPluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 
 namespace fs = std::filesystem;
 

--- a/src/deployers/SvgPluginsDeployer.cpp
+++ b/src/deployers/SvgPluginsDeployer.cpp
@@ -2,13 +2,13 @@
 #include <filesystem>
 
 // library headers
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 
 // local headers
 #include "SvgPluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 
 namespace fs = std::filesystem;
 

--- a/src/deployers/WebEnginePluginsDeployer.cpp
+++ b/src/deployers/WebEnginePluginsDeployer.cpp
@@ -3,14 +3,14 @@
 #include <fstream>
 
 // library headers
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 #include <util.h>
 
 // local headers
 #include "WebEnginePluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 
 namespace fs = std::filesystem;
 

--- a/src/deployers/XcbglIntegrationPluginsDeployer.cpp
+++ b/src/deployers/XcbglIntegrationPluginsDeployer.cpp
@@ -1,12 +1,12 @@
 // library headers
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 
 // local headers
 #include "XcbglIntegrationPluginsDeployer.h"
 #include "deployment.h"
 
 using namespace linuxdeploy::plugin::qt;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 
 bool XcbglIntegrationPluginsDeployer::doDeploy() {
     ldLog() << "Deploying xcb-gl integrations" << std::endl;

--- a/src/deployment.h
+++ b/src/deployment.h
@@ -7,7 +7,7 @@
 // library includes
 #include <linuxdeploy/core/appdir.h>
 #include <linuxdeploy/core/elf_file.h>
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 #include <linuxdeploy/util/util.h>
 
 // local includes
@@ -19,7 +19,7 @@ namespace fs = std::filesystem;
 
 using namespace linuxdeploy::core;
 using namespace linuxdeploy::util::misc;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 
 // little helper called by other integration plugins
 inline bool deployIntegrationPlugins(appdir::AppDir& appDir, const fs::path& qtPluginsPath, const std::initializer_list<fs::path>& subDirs) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 // library includes
 #include <linuxdeploy/core/appdir.h>
 #include <linuxdeploy/core/elf_file.h>
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 #include <linuxdeploy/util/util.h>
 
 // local includes
@@ -22,7 +22,7 @@ namespace fs = std::filesystem;
 
 using namespace linuxdeploy::core;
 using namespace linuxdeploy::util::misc;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 using namespace linuxdeploy::plugin::qt;
 
 

--- a/src/qml.cpp
+++ b/src/qml.cpp
@@ -4,7 +4,7 @@
 // library includes
 #include <nlohmann/json.hpp>
 #include <linuxdeploy/core/appdir.h>
-#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/log/log.h>
 #include <linuxdeploy/core/elf_file.h>
 #include <linuxdeploy/subprocess/subprocess.h>
 #include <linuxdeploy/util/util.h>
@@ -14,7 +14,7 @@
 #include "qml.h"
 
 using namespace linuxdeploy::core;
-using namespace linuxdeploy::core::log;
+using namespace linuxdeploy::log;
 using namespace linuxdeploy::subprocess;
 using namespace linuxdeploy::util;
 using namespace nlohmann;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,6 +2,7 @@
 #include <assert.h>
 
 // library headers
+#include <linuxdeploy/log/log.h>
 #include <linuxdeploy/util/util.h>
 #include <linuxdeploy/subprocess/subprocess.h>
 
@@ -13,7 +14,7 @@ using namespace linuxdeploy::subprocess;
 std::map<std::string, std::string> queryQmake(const std::filesystem::path& qmakePath) {
     auto qmakeCall = subprocess({qmakePath.string(), "-query"}).run();
 
-    using namespace linuxdeploy::core::log;
+    using namespace linuxdeploy::log;
 
     if (qmakeCall.exit_code() != 0) {
         ldLog() << LD_ERROR << "Call to qmake failed:" << qmakeCall.stderr_string() << std::endl;
@@ -54,7 +55,7 @@ std::map<std::string, std::string> queryQmake(const std::filesystem::path& qmake
 };
 
 std::filesystem::path findQmake() {
-    using namespace linuxdeploy::core::log;
+    using namespace linuxdeploy::log;
 
     std::filesystem::path qmakePath;
 

--- a/src/util.h
+++ b/src/util.h
@@ -10,7 +10,6 @@
 
 // library includes
 #include <args.hxx>
-#include <linuxdeploy/core/log.h>
 
 typedef struct {
     bool success;


### PR DESCRIPTION
Since I needed linuxdeploy-plugin-qt that had the --exclude-libraries working I make the github workflows run on my fork and and have this issue when using a newer (+my patch) linuxdeploy submodule.