### PR TITLE
Don't fail on non-existent plugin directory.

### DIFF
--- a/src/deployers/BasicPluginsDeployer.cpp
+++ b/src/deployers/BasicPluginsDeployer.cpp
@@ -38,6 +38,10 @@ bool BasicPluginsDeployer::deployStandardQtPlugins(const std::vector<std::string
 {
     for (const auto &pluginName : plugins) {
         ldLog() << "Deploying Qt" << pluginName << "plugins" << std::endl;
+        if (!fs::exists(qtPluginsPath / pluginName)) {
+            ldLog() << LD_WARNING << "No plugin path found for Qt" << pluginName << std::endl;
+            continue;
+        }
         for (fs::directory_iterator i(qtPluginsPath / pluginName); i != fs::directory_iterator(); ++i) {
             if (i->path().extension() == ".debug") {
                 ldLog() << LD_DEBUG << "skipping .debug file:" << i->path() << std::endl;


### PR DESCRIPTION
When no plugins are available, Qt doesn't create a folder for them. For example, Qt might build with printsupport, but not create the printsupport plugins directory, because CUPS isn't installed and no libcupsprintersupport.so plugin was built.

Without this patch, packaging fails for me when trying to package Qt provided by Conan:
```
[qt/stdout] -- Deploying module: positioning -- 
[qt/stdout] Deploying Qt position plugins 
[qt/stdout] Deploying shared library /home/juliangro/.conan2/p/b/qtd40e1b81d798c/p/plugins/position/libqtposition_positionpoll.so (destination: /home/juliangro/git/overte/build/_CPack_Packages/Linux/External/Overte-Dev-2026-02-26-0/usr/plugins/position/)
[qt/stdout] WARNING: Could not find copyright files for file /home/juliangro/.conan2/p/b/qtd40e1b81d798c/p/plugins/position/libqtposition_positionpoll.so using dpkg-query 
[qt/stdout] Deploying dependencies for ELF file /home/juliangro/.conan2/p/b/qtd40e1b81d798c/p/plugins/position/libqtposition_positionpoll.so 
[qt/stdout] Deploying shared library /home/juliangro/.conan2/p/b/qtd40e1b81d798c/p/lib/libQt5Positioning.so.5
[qt/stdout] WARNING: Could not find copyright files for file /home/juliangro/.conan2/p/b/qtd40e1b81d798c/p/lib/libQt5Positioning.so.5 using dpkg-query 
[qt/stderr] terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
[qt/stderr]   what():  filesystem error: directory iterator cannot open directory: No such file or directory [/home/juliangro/.conan2/p/b/qtd40e1b81d798c/p/plugins/printsupport]
[qt/stdout] 
[qt/stdout] -- Deploying module: printsupport -- 
[qt/stdout] Deploying Qt printsupport plugins 
ERROR: Failed to run plugin: qt (exit code: 6) 
```

Granted, this is probably an edge case, since system packages would have the plugins and custom built packages would *usually* find system CUPS and build the plugin.