### PR TITLE
Remove redundant nlohmann_json alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ if(NOT nlohmann_json_FOUND)
     )
 
     FetchContent_MakeAvailable(nlohmann_json)
-
-    add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
 endif()
 
 add_subdirectory(lib)


### PR DESCRIPTION
Fixes CMake error:
```
CMake Error at CMakeLists.txt:31 (add_library):
  add_library cannot create ALIAS target "nlohmann_json::nlohmann_json"
  because another target with the same name already exists.
```