### PR TITLE
Fix findQmlImportScanner() on FreeBSD

### DIFF
--- a/src/qml.cpp
+++ b/src/qml.cpp
@@ -1,6 +1,10 @@
 // system headers
 #include <filesystem>
 
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#endif
+
 // library includes
 #include <nlohmann/json.hpp>
 #include <linuxdeploy/core/appdir.h>
@@ -22,7 +26,18 @@ using namespace nlohmann;
 namespace fs = std::filesystem;
 
 fs::path findQmlImportScanner() {
-    return which("qmlimportscanner");
+    auto path = which("qmlimportscanner");
+    if (path.empty()) {
+        // at least on FreeBSD the qmlimportscanner binary is installed under
+        // QT_INSTALL_LIBEXECS for Qt 6 and QT_INSTALL_BINS for Qt5,
+        // so is not locatable via $PATH
+        auto qmakeVars = queryQmake(findQmake());
+        path = which(qmakeVars["QT_INSTALL_LIBEXECS"] + "/qmlimportscanner");
+        if (path.empty())
+            path = which(qmakeVars["QT_INSTALL_BINS"] + "/qmlimportscanner");
+    }
+
+    return path;
 }
 
 std::string runQmlImportScanner(const std::vector<std::filesystem::path> &sourcesPaths, const std::vector<fs::path> &qmlImportPaths) {

--- a/tests/test_deploy_qml.cpp
+++ b/tests/test_deploy_qml.cpp
@@ -52,10 +52,9 @@ namespace linuxdeploy {
 
                 TEST_F(TestDeployQml, find_qmlimporter_path) {
                     auto result = findQmlImportScanner();
-                    std::filesystem::path expected = "/usr/bin/qmlimportscanner";
 
                     ASSERT_FALSE(result.empty());
-                    ASSERT_EQ(result.string(), expected.string());
+                    ASSERT_EQ(result.filename().string(), "qmlimportscanner");
                 }
 
                 TEST_F(TestDeployQml, runQmlImportScanner) {


### PR DESCRIPTION
We don't install the qmlimportscanner executable into public location, so add a bit of extra logic to locate it.